### PR TITLE
fix: auto replace scroll

### DIFF
--- a/components/common/card/Card.module.css
+++ b/components/common/card/Card.module.css
@@ -2,7 +2,7 @@
   width: fit-content;
   background: white;
   border-radius: 8px;
-  overflow-x: scroll;
+  overflow-x: auto;
 
   padding: 0.25rem 0;
   display: flex;


### PR DESCRIPTION
## Description

`overflow` default value is `visible`. 

If the content intend to scroll, use `auto` will better than `scroll`.

`scroll` will always show the scroll bar.

Ticket: [SQN-1518](https://onfinality.atlassian.net/browse/SQN-1518)

## UI Changes

<img width="1281" alt="微信截图_20230613111137" src="https://github.com/subquery/subql-ui-components/assets/10172415/5688eecd-be69-4b23-a28b-ef9a60549887">

