### PR TITLE
feat: add grqphiql theme

### DIFF
--- a/components/common/GraphiQL/GraphiQL.stories.tsx
+++ b/components/common/GraphiQL/GraphiQL.stories.tsx
@@ -9,11 +9,13 @@ export default {
   component: GraphiQL,
 } as ComponentMeta<typeof GraphiQL>;
 
-const Template: ComponentStory<typeof GraphiQL> = (args) => (
-  <div style={{ height: '100vh' }}>
-    <GraphiQL {...args} />
-  </div>
-);
+const Template: ComponentStory<typeof GraphiQL> = (args) => {
+  return (
+    <div style={{ height: '100vh' }}>
+      <GraphiQL {...args} theme="dark" />
+    </div>
+  );
+};
 
 export const Default = Template.bind({});
 

--- a/components/common/GraphiQL/GraphiQL.tsx
+++ b/components/common/GraphiQL/GraphiQL.tsx
@@ -4,16 +4,18 @@
 import { createGraphiQLFetcher } from '@graphiql/toolkit';
 import { GraphiQL as GraphiQLPlayground, GraphiQLProps } from 'graphiql';
 import { useExplorerPlugin } from '@graphiql/plugin-explorer';
-import { useMemo, useState } from 'react';
-
+import { useEffect, useMemo, useState } from 'react';
+import { useTheme } from '@graphiql/react';
 import 'graphiql/graphiql.min.css';
 import '@graphiql/plugin-explorer/dist/style.css';
 import './GraphiQL.module.css';
 
-export interface IGraphiQL extends GraphiQLProps {
+export interface IGraphiQL extends Omit<GraphiQLProps, 'fetcher'> {
   bearToken?: string;
   url: string;
   explorerDefaultOpen?: boolean;
+  fetcher?: GraphiQLProps['fetcher'];
+  theme: 'dark' | 'light';
 }
 
 const defaultHeaders = {
@@ -27,8 +29,10 @@ export const GraphiQL: React.FC<IGraphiQL> = ({
   defaultQuery,
   explorerDefaultOpen,
   onEditQuery,
+  theme = 'light',
   ...graphiQLProps
 }) => {
+  const { setTheme } = useTheme();
   // The fetcher is defined once and doesnt need to be re-rendered everytime
   const sortedFetcher = useMemo(() => {
     const sortedHeaders = bearToken //
@@ -62,6 +66,10 @@ export const GraphiQL: React.FC<IGraphiQL> = ({
     plugins: [explorerPlugin],
     visiblePlugin: explorerDefaultOpen ? explorerPlugin.title : '',
   };
+
+  useEffect(() => {
+    setTheme(theme);
+  }, [theme]);
 
   return <GraphiQLPlayground {...props} />;
 };

--- a/components/common/GraphiQL/GraphiQL.tsx
+++ b/components/common/GraphiQL/GraphiQL.tsx
@@ -11,11 +11,11 @@ import '@graphiql/plugin-explorer/dist/style.css';
 import './GraphiQL.module.css';
 
 export interface IGraphiQL extends Omit<GraphiQLProps, 'fetcher'> {
-  bearToken?: string;
   url: string;
+  bearToken?: string;
   explorerDefaultOpen?: boolean;
   fetcher?: GraphiQLProps['fetcher'];
-  theme: 'dark' | 'light';
+  theme?: 'dark' | 'light';
 }
 
 const defaultHeaders = {


### PR DESCRIPTION
## Description

- Add a way that can set theme by programming for GraphiQL.
- Enhance the type definition, fetcher is not required.

## UI Changes


![image](https://github.com/subquery/subql-ui-components/assets/10172415/03029aa9-c024-4366-b37a-0e6a7258bfe1)
